### PR TITLE
Make `Conditional` inherently scalar

### DIFF
--- a/examples/polyhedra.jl
+++ b/examples/polyhedra.jl
@@ -1,4 +1,6 @@
 using Base.Test
+using JuMP
+using Cbc
 using ConditionalJuMP
 using Polyhedra: SimpleHRepresentation
 
@@ -8,8 +10,10 @@ using Polyhedra: SimpleHRepresentation
 # This implementation lets us add disjunctions and implications of the form
 #   x in P
 # where x is a vector and P is a Polyhedron
-function ConditionalJuMP.Conditional(op::typeof(in), x::AbstractVector, P::SimpleHRepresentation)
-    ConditionalJuMP.Conditional(&, [@?(P.A[i, :]' * x <= P.b[i]) for i in 1:length(P)]...)
+function ConditionalJuMP.Conditional(op::typeof(in), args::Tuple{AbstractVector, SimpleHRepresentation})
+    x, P = args
+    (&)([@?(P.A[i, :]' * x <= P.b[i]) for i in 1:length(P)]...)
+    # ConditionalJuMP.Conditional(&, Tuple([@?(P.A[i, :]' * x <= P.b[i]) for i in 1:length(P)]))
 end
 
 # A simple L1-norm objective we can minimize (since the Cbc 

--- a/examples/polyhedra.jl
+++ b/examples/polyhedra.jl
@@ -13,7 +13,6 @@ using Polyhedra: SimpleHRepresentation
 function ConditionalJuMP.Conditional(op::typeof(in), args::Tuple{AbstractVector, SimpleHRepresentation})
     x, P = args
     (&)([@?(P.A[i, :]' * x <= P.b[i]) for i in 1:length(P)]...)
-    # ConditionalJuMP.Conditional(&, Tuple([@?(P.A[i, :]' * x <= P.b[i]) for i in 1:length(P)]))
 end
 
 # A simple L1-norm objective we can minimize (since the Cbc 

--- a/src/ConditionalJuMP.jl
+++ b/src/ConditionalJuMP.jl
@@ -262,14 +262,6 @@ function implies!(m::Model, z::AbstractJuMPScalar, c::Conditional{typeof(<=), <:
     @constraint m lhs <= rhs + M * (1 - z)
 end 
 
-# function implies!(m::Model, z::AbstractJuMPScalar, c::Conditional{typeof(<=), <:NTuple{2, AbstractArray})
-#     lhs, rhs = c.args
-#     g = lhs .- rhs
-#     M = upperbound.(g)
-#     @assert all(isfinite(M))
-#     @constraint m lhs .<= rhs .+ M .* (1 .- z)
-# end 
-
 function implies!(m::Model, z::AbstractJuMPScalar, c::Conditional{typeof(==), <:Narg{2}})
     lhs, rhs = c.args
     g = lhs - rhs
@@ -280,17 +272,6 @@ function implies!(m::Model, z::AbstractJuMPScalar, c::Conditional{typeof(==), <:
     @constraint(m, lhs - rhs <= M_u * (1 - z))
     @constraint(m, lhs - rhs >= M_l * (1 - z))
 end 
-
-# function implies!(m::Model, z::AbstractJuMPScalar, c::Conditional{typeof(==), <:NTuple{2, AbstractArray}})
-#     lhs, rhs = c.args
-#     g = lhs .- rhs
-#     M_u = upperbound.(g)
-#     @assert all(isfinite, M_u)
-#     M_l = lowerbound.(g)
-#     @assert all(isfinite, M_l)
-#     @constraint(m, lhs .- rhs .<= M_u .* (1 .- z))
-#     @constraint(m, lhs .- rhs .>= M_l .* (1 .- z))
-# end 
 
 implies!(::Model, ::AbstractJuMPScalar, ::Void) = nothing
 implies!(::Model, ::AbstractJuMPScalar, ::ComplementNotDefined) = nothing

--- a/src/ConditionalJuMP.jl
+++ b/src/ConditionalJuMP.jl
@@ -47,15 +47,15 @@ function _setvalue(s::JuMP.GenericAffExpr, x)
     _setvalue(s.vars[1], (x - s.constant) / s.coeffs[1])
 end
 
-struct Conditional{Op, Args<:Tuple}
+struct Conditional{Op, Args <: Tuple}
     op::Op
     args::Args
-end
 
-function Conditional(op::Op, args...) where {Op}
-    canonical_op, canonical_args = canonicalize(op, args)
-    Conditional{typeof(canonical_op), typeof(canonical_args)}(
-        canonical_op, canonical_args)
+    function Conditional(op, args) where {}
+        canonical_op, canonical_args = canonicalize(op, args)
+        new{typeof(canonical_op), typeof(canonical_args)}(
+            canonical_op, canonical_args)
+    end
 end
 
 function getmodel(c::Conditional)
@@ -67,8 +67,8 @@ function getmodel(c::Conditional)
     error("Could not find JuMP Model in conditional $c")
 end
 
-Conditional(::typeof(>=), x, y) = Conditional(<=, -x, -y)
-(&)(c1::Conditional, c2::Conditional) = Conditional(&, c1, c2)
+Conditional(::typeof(>=), x, y) = Conditional(<=, (-x, -y))
+(&)(c1::Conditional, cs::Conditional...) = Conditional(&, (c1, cs...))
 
 Narg{N} = Tuple{Vararg{Any, N}}
 
@@ -82,10 +82,11 @@ Base.show(io::IO, c::Conditional) = print(io, c.op, c.args)
 canonicalize(op, args) = op, args
 canonicalize(op::typeof(>=), args::Tuple{Vararg{<:Any, 2}}) = (<=, (args[2] - args[1], 0))
 canonicalize(op::typeof(<=), args::Tuple{Vararg{<:Any, 2}}) = (<=, (args[1] - args[2], 0))
+# canonicalize(c::Conditional) = canonicalize(c.op, c.args)
 
 (==)(c1::Conditional{op}, c2::Conditional{op}) where {op} = c1.args == c2.args
 
-Base.hash(c::Conditional{typeof(>=)}, h::UInt) = hash(canonicalize(c), h)
+# Base.hash(c::Conditional{typeof(>=)}, h::UInt) = hash(canonicalize(c), h)
 
 # work-around because JuMP doesn't properly define hash()
 function _hash(x::JuMP.GenericAffExpr, h::UInt)
@@ -114,8 +115,8 @@ struct ComplementNotDefined
 end
 
 complement(c::Conditional) = ComplementNotDefined()
-complement(c::Conditional{typeof(<=), <:Narg{2}}) = Conditional(<=, c.args[2], c.args[1])
-complement(c::Conditional{typeof(>=), <:Narg{2}}) = Conditional(<=, c.args[1], c.args[2])
+complement(c::Conditional{typeof(<=), <:Narg{2}}) = Conditional(<=, (c.args[2], c.args[1]))
+complement(c::Conditional{typeof(>=), <:Narg{2}}) = Conditional(<=, (c.args[1], c.args[2]))
 (!)(c::Conditional) = complement(c)
 
 Base.@pure isjump(x) = false
@@ -127,13 +128,17 @@ Base.@pure isjump(x::AbstractArray{<:AbstractJuMPScalar}) = true
 
 function _conditional(op::Op, args...) where {Op <: Union{typeof(<=), typeof(>=), typeof(==), typeof(in)}}
     if isjump(args)
-        Conditional(op, args...)
+        Conditional(op, args)
     else
         op(args...)
     end
 end
 
 _conditional(op, args...) = op(args...)
+
+function _all_conditional(args)
+    (&)(args...)
+end
 
 lowerbound(x::Number) = x
 lowerbound(x::AbstractJuMPScalar) = -upperbound(-x)
@@ -218,8 +223,8 @@ end
 
 function disjunction!(indmap::IndicatorMap, imps::NTuple{2, Implication})
     z = getindicator!(indmap, first(imps[1]))
-    zs = [z, 1 - z]
-    _addimplication!.(indmap, zs, imps)
+    _addimplication!(indmap, z, imps[1])
+    _addimplication!(indmap, 1 - z, imps[2])
     push!(indmap.disjunctions, Implication[imps...])
 end
 
@@ -249,34 +254,43 @@ function implies!(m::Model, imp::Implication)
     disjunction!(m, (imp, (comp1 => nothing)))
 end
 
-
 function implies!(m::Model, z::AbstractJuMPScalar, c::Conditional{typeof(<=), <:Narg{2}})
     lhs, rhs = c.args
-    g = lhs .- rhs
-    M = upperbound.(g)
+    g = lhs - rhs
+    M = upperbound(g)
     @assert all(isfinite(M))
-    if isa(g, AbstractArray)
-        @constraint m lhs .<= rhs .+ M .* (1 .- z)
-    else
-        @constraint m lhs <= rhs + M * (1 - z)
-    end
+    @constraint m lhs <= rhs + M * (1 - z)
 end 
+
+# function implies!(m::Model, z::AbstractJuMPScalar, c::Conditional{typeof(<=), <:NTuple{2, AbstractArray})
+#     lhs, rhs = c.args
+#     g = lhs .- rhs
+#     M = upperbound.(g)
+#     @assert all(isfinite(M))
+#     @constraint m lhs .<= rhs .+ M .* (1 .- z)
+# end 
 
 function implies!(m::Model, z::AbstractJuMPScalar, c::Conditional{typeof(==), <:Narg{2}})
     lhs, rhs = c.args
-    g = lhs .- rhs
-    M_u = upperbound.(g)
+    g = lhs - rhs
+    M_u = upperbound(g)
     @assert all(isfinite, M_u)
-    M_l = lowerbound.(g)
+    M_l = lowerbound(g)
     @assert all(isfinite, M_l)
-    if isa(g, AbstractArray)
-        @constraint(m, lhs .- rhs .<= M_u .* (1 .- z))
-        @constraint(m, lhs .- rhs .>= M_l .* (1 .- z))
-    else
-        @constraint(m, lhs - rhs <= M_u * (1 - z))
-        @constraint(m, lhs - rhs >= M_l * (1 - z))
-    end
+    @constraint(m, lhs - rhs <= M_u * (1 - z))
+    @constraint(m, lhs - rhs >= M_l * (1 - z))
 end 
+
+# function implies!(m::Model, z::AbstractJuMPScalar, c::Conditional{typeof(==), <:NTuple{2, AbstractArray}})
+#     lhs, rhs = c.args
+#     g = lhs .- rhs
+#     M_u = upperbound.(g)
+#     @assert all(isfinite, M_u)
+#     M_l = lowerbound.(g)
+#     @assert all(isfinite, M_l)
+#     @constraint(m, lhs .- rhs .<= M_u .* (1 .- z))
+#     @constraint(m, lhs .- rhs .>= M_l .* (1 .- z))
+# end 
 
 implies!(::Model, ::AbstractJuMPScalar, ::Void) = nothing
 implies!(::Model, ::AbstractJuMPScalar, ::ComplementNotDefined) = nothing
@@ -305,7 +319,7 @@ function switch!(m::Model, args::Pair{<:Conditional, <:AbstractArray}...)
         setlowerbound(y[I], minimum(v -> lowerbound(v[I]), values))
         setupperbound(y[I], maximum(v -> upperbound(v[I]), values))
     end
-    disjunction!(m, map(cv -> (cv[1] => @?(y == cv[2])), args))
+    disjunction!(m, map(cv -> (cv[1] => @?(y .== cv[2])), args))
     y
 end
 
@@ -326,7 +340,8 @@ function Base.ifelse(c::Conditional, v1::AbstractArray, v2::AbstractArray)
     y = reshape(@variable(m, y[1:length(v1)], basename="y"), size(v1))
     setlowerbound.(y, min.(lowerbound.(v1), lowerbound.(v2)))
     setupperbound.(y, max.(upperbound.(v1), upperbound.(v2)))
-    disjunction!(m, (c => @?(y == v1), !c => @?(y == v2)))
+    @disjunction(m, (c => y .== v1), (!c => (y .== v2)))
+    # disjunction!(m, (c => @?(y .== v1), !c => @?(y .== v2)))
     y
 end
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,10 +1,23 @@
 _conditionalize(ex) = esc(ex)
 
+is_function_broadcast(ex::Expr) = ex.head == :(.) && ex.args[2].head == :tuple
+is_operator_broadcast(ex::Expr) = ex.head == :(call) && isa(ex.args[1], Symbol) && string(ex.args[1])[1] === '.'
+
+function _conditionalize_function_broadcast(ex::Expr)
+    Expr(:call, :_all_conditional, Expr(:call, GlobalRef(Base, :broadcast), :_conditional, esc(ex.args[1]), esc.(ex.args[2].args)...))
+end
+
+function _conditionalize_operator_broadcast(ex::Expr)
+    Expr(:call, :_all_conditional, Expr(:call, GlobalRef(Base, :broadcast), :_conditional, esc(Symbol(string(ex.args[1])[2:end])), esc.(ex.args[2:end])...))
+end
+
 function _conditionalize(ex::Expr)
-    if ex.head == :call 
-        if ex.args[1] == GlobalRef(Base, :broadcast)
-            Expr(:call, :_all_conditional, Expr(:call, GlobalRef(Base, :broadcast), :_conditional, esc.(ex.args[2:end])...))
-        elseif ex.args[1] == :(=>)
+    if is_function_broadcast(ex)
+        _conditionalize_function_broadcast(ex)
+    elseif is_operator_broadcast(ex)
+        _conditionalize_operator_broadcast(ex)
+    elseif ex.head == :call
+        if ex.args[1] == :(=>)
             Expr(:call, :(=>), _conditionalize.(ex.args[2:end])...)
         else
             Expr(:call, :_conditional, _conditionalize.(ex.args)...)
@@ -15,22 +28,22 @@ function _conditionalize(ex::Expr)
 end
 
 macro ?(ex)
-    _conditionalize(expand(ex))
+    _conditionalize(ex)
 end
 
 
 macro implies(m, args...)
-    Expr(:call, :implies!, esc(m), _conditionalize.(expand.(args))...)
+    Expr(:call, :implies!, esc(m), _conditionalize.(args)...)
 end
 
 macro disjunction(m, args...)
-    Expr(:call, :disjunction!, esc(m), Expr(:tuple, _conditionalize.(expand.(args))...))
+    Expr(:call, :disjunction!, esc(m), Expr(:tuple, _conditionalize.(args)...))
 end
 
 macro switch(args...)
-    Expr(:call, :switch, _conditionalize.(expand.(args))...)
+    Expr(:call, :switch, _conditionalize.(args)...)
 end
 
 macro ifelse(c, v1, v2)
-    Expr(:call, :ifelse, _conditionalize(expand(c)), v1, v2)
+    Expr(:call, :ifelse, _conditionalize(c), v1, v2)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,7 +85,7 @@ end
         m = Model(solver=CbcSolver())
         @variable m -5 <= x <= 5
         @variable m -5 <= y[1:2] <= 5
-        @implies m x ≤ 0 => y == [3, 3.5]
+        @implies m x ≤ 0 => y .== [3, 3.5]
         @objective m Min x
         @test sum(m.colCat .== :Bin) == 1
         solve(m)
@@ -97,7 +97,7 @@ end
         m = Model(solver=CbcSolver())
         @variable m -5 <= x <= 5
         @variable m -5 <= y[1:2] <= 5
-        @implies m x ≥ 0 => y == [1, -1]
+        @implies m x ≥ 0 => y .== [1, -1]
         @objective m Max x
         @test sum(m.colCat .== :Bin) == 1
         solve(m)


### PR DESCRIPTION
Rather than storing `y <= [1, 2, 3]` as `Conditional(<=, y, [1, 2, 3])`, instead store it as `Conditional(&, Conditional(<=, y[1], 1), ...)`. This simplifies some internal code and makes more sense to me. 

Still todo: figure out how to handle the vector forms of `ifelse` and `switch` more sensibly. 