### PR TITLE
Improve performance for simplification of expressions with large amounts of variables

### DIFF
--- a/src/ConditionalJuMP.jl
+++ b/src/ConditionalJuMP.jl
@@ -26,11 +26,7 @@ of variables.
 """
 function simplify!(e::JuMP.GenericAffExpr{T, Variable}) where T
     n = length(e.vars)
-    # println(n)
-    ((n < 100) ? simplify_inplace! : simplify_dict)(e)
-    # tic()
-    simplify_inplace!(e)
-    # toc()
+    ((n < 100) ? simplify_inplace! : simplify_dict!)(e)
 end
 
 """
@@ -67,7 +63,7 @@ end
 O(N) simplification, but with a substantially larger constant cost due to the
 need to construct a Dict. 
 """
-function simplify_dict(e::JuMP.GenericAffExpr{T, Variable}) where T
+function simplify_dict!(e::JuMP.GenericAffExpr{T, Variable}) where T
     vars = Variable[]
     coeffs = T[]
 
@@ -89,6 +85,9 @@ function simplify_dict(e::JuMP.GenericAffExpr{T, Variable}) where T
     if iszero(constant)
         constant = zero(constant)
     end
+    e.vars = vars
+    e.coeffs = coeffs
+    e.constant = constant
     AffExpr(vars, coeffs, constant)
 end
 

--- a/src/ConditionalJuMP.jl
+++ b/src/ConditionalJuMP.jl
@@ -21,10 +21,23 @@ include("macros.jl")
 const NArg{N} = NTuple{N, Any}
 
 """
+Simplification function that chooses the appropriate algorithm based on the number
+of variables.
+"""
+function simplify!(e::JuMP.GenericAffExpr{T, Variable}) where T
+    n = length(e.vars)
+    # println(n)
+    ((n < 100) ? simplify_inplace! : simplify_dict)(e)
+    # tic()
+    simplify_inplace!(e)
+    # toc()
+end
+
+"""
 Naive O(N^2) simplification. Slower for very large expressions, but allocates
 no memory and is solidly faster for expressions with < 100 variables. 
 """
-function simplify!(e::JuMP.GenericAffExpr{T, Variable}) where T
+function simplify_inplace!(e::JuMP.GenericAffExpr{T, Variable}) where T
     i1 = 1
     iend = length(e.vars)
     while i1 < iend
@@ -54,7 +67,7 @@ end
 O(N) simplification, but with a substantially larger constant cost due to the
 need to construct a Dict. 
 """
-function simplify(e::JuMP.GenericAffExpr{T, Variable}) where T
+function simplify_dict(e::JuMP.GenericAffExpr{T, Variable}) where T
     vars = Variable[]
     coeffs = T[]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,10 @@ end
         for i in 1:1000
             N = rand(1:20)
             x = randn(N)' * rand(q, N)
-            s1 = ConditionalJuMP.simplify_dict(copy(x))
-            s2 = ConditionalJuMP.simplify_inplace!(copy(x))
+            s1 = copy(x)
+            s2 = copy(x)
+            ConditionalJuMP.simplify_dict!(s1)
+            ConditionalJuMP.simplify_inplace!(s2)
             @test s1.constant == s2.constant
             @test length(s1.vars) == length(s2.vars)
             @test length(s1.coeffs) == length(s2.coeffs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,8 @@ end
         for i in 1:1000
             N = rand(1:20)
             x = randn(N)' * rand(q, N)
-            s1 = ConditionalJuMP.simplify(copy(x))
-            s2 = ConditionalJuMP.simplify!(copy(x))
+            s1 = ConditionalJuMP.simplify_dict(copy(x))
+            s2 = ConditionalJuMP.simplify_inplace!(copy(x))
             @test s1.constant == s2.constant
             @test length(s1.vars) == length(s2.vars)
             @test length(s1.coeffs) == length(s2.coeffs)


### PR DESCRIPTION
  + Code  
     + Select O(n^2) simplification if number of variables is small, and O(n) simplification otherwise.
     + Make `simplify_dict` modify the underlying expression (to maintain the same behavior as `simplify_inplace!`.
  + Tests
     + Add testing to ensure that performance for large number of variables is reasonable.
     + Loosen equality requirements on coefficients of simplified expression in tests